### PR TITLE
feat: remove auto_execute parameter and fix MCP integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,24 @@ Langchain / Langgraph integration for Snowflake Cortex AI. Native support for ch
 
 ## Features
 
-- Chat models with tool calling support
-- Cortex Search retrieval with relevance assessment
-- Cortex Analyst with semantic Text2SQL support
-- Complete toolkit for Cortex AI functions
-- Async/await support for high-performance applications
-- Agent patterns following Langchain & Langgraph standards
-- Multiple authentication methods
-- Consolidated error handling
-- LangSmith tracing integration
-- 50+ comprehensive tests covering core functionality
+### Core Capabilities
+- **Chat Models** - Native Snowflake Cortex LLM support (Claude, Llama, Mistral, GPT-4)
+- **Tool Calling** - Standard LangChain tool binding with Snowflake Cortex functions
+- **Structured Output** - Pydantic and JSON schema support
+- **Streaming** - Real-time response streaming for better UX
+
+### Snowflake Cortex AI Integration
+- **Cortex Search** - Semantic search with relevance scoring
+- **Cortex Analyst** - Natural language to SQL via semantic models
+- **Cortex Agents** - Managed agent orchestration with thread management
+- **Cortex Complete** - Text generation and completion
+
+### Production Ready
+- **Multiple Authentication** - Password, PAT, Key Pair, SSO
+- **Async/Await Support** - High-performance async operations
+- **Error Handling** - Comprehensive error recovery
+- **LangSmith Integration** - Built-in observability and tracing
+- **50+ Tests** - Comprehensive test coverage
 
 ## Installation
 
@@ -39,17 +47,17 @@ export LANGCHAIN_PROJECT=snowflake-cortex
 - [Snowflake Workflows](https://github.com/langchain-ai/langchain-snowflake/blob/main/libs/snowflake/docs/snowflake_workflows.ipynb)
 - [Advanced Patterns](https://github.com/langchain-ai/langchain-snowflake/blob/main/libs/snowflake/docs/advanced_patterns.ipynb)
 - [Quickstart](https://quickstarts.snowflake.com/guide/build-evaluate-rag-langchain-snowflake/index.html?index=..%2F..index#0)
+- [Multi-Agent Demo]() - coming soon
 
 ## Contributing
 
-See [Development.md](https://github.com/langchain-ai/langchain-snowflake/blob/main/libs/snowflake/DEVELOPMENT.md) for setup and guidelines.
+We welcome contributions! See [Development.md](https://github.com/langchain-ai/langchain-snowflake/blob/main/libs/snowflake/DEVELOPMENT.md) for setup and guidelines.
 
 ## License
 
-MIT License
+MIT License - see [LICENSE](https://github.com/langchain-ai/langchain-snowflake/blob/main/libs/snowflake/LICENSE) for details
 
 ## Support
 
 - Check documentation notebooks in `docs/`
-- Report issues on GitHub
-- Join community discussions
+- Report issues on [GitHub Issues](https://github.com/langchain-ai/langchain-snowflake/issues)

--- a/libs/snowflake/README.md
+++ b/libs/snowflake/README.md
@@ -4,16 +4,24 @@ Langchain / Langgraph integration for Snowflake Cortex AI. Native support for ch
 
 ## Features
 
-- Chat models with tool calling support
-- Cortex Search retrieval with relevance assessment
-- Cortex Analyst with semantic Text2SQL support
-- Complete toolkit for Cortex AI functions
-- Async/await support for high-performance applications
-- Agent patterns following Langchain & Langgraph standards
-- Multiple authentication methods
-- Consolidated error handling
-- LangSmith tracing integration
-- 50+ comprehensive tests covering core functionality
+### Core Capabilities
+- **Chat Models** - Native Snowflake Cortex LLM support (Claude, Llama, Mistral, GPT-4)
+- **Tool Calling** - Standard LangChain tool binding with Snowflake Cortex functions
+- **Structured Output** - Pydantic and JSON schema support
+- **Streaming** - Real-time response streaming for better UX
+
+### Snowflake Cortex AI Integration
+- **Cortex Search** - Semantic search with relevance scoring
+- **Cortex Analyst** - Natural language to SQL via semantic models
+- **Cortex Agents** - Managed agent orchestration with thread management
+- **Cortex Complete** - Text generation and completion
+
+### Production Ready
+- **Multiple Authentication** - Password, PAT, Key Pair, SSO
+- **Async/Await Support** - High-performance async operations
+- **Error Handling** - Comprehensive error recovery
+- **LangSmith Integration** - Built-in observability and tracing
+- **50+ Tests** - Comprehensive test coverage
 
 ## Installation
 
@@ -35,17 +43,17 @@ export LANGCHAIN_PROJECT=snowflake-cortex
 - [Snowflake Workflows](https://github.com/langchain-ai/langchain-snowflake/blob/main/libs/snowflake/docs/snowflake_workflows.ipynb)
 - [Advanced Patterns](https://github.com/langchain-ai/langchain-snowflake/blob/main/libs/snowflake/docs/advanced_patterns.ipynb)
 - [Quickstart](https://quickstarts.snowflake.com/guide/build-evaluate-rag-langchain-snowflake/index.html?index=..%2F..index#0)
+- [Multi-Agent Demo]() - coming soon
 
 ## Contributing
 
-See [Development.md](https://github.com/langchain-ai/langchain-snowflake/blob/main/libs/snowflake/DEVELOPMENT.md) for setup and guidelines.
+We welcome contributions! See [Development.md](https://github.com/langchain-ai/langchain-snowflake/blob/main/libs/snowflake/DEVELOPMENT.md) for setup and guidelines.
 
 ## License
 
-MIT License
+MIT License - see [LICENSE](https://github.com/langchain-ai/langchain-snowflake/blob/main/libs/snowflake/LICENSE) for details
 
 ## Support
 
 - Check documentation notebooks in `docs/`
-- Report issues on GitHub
-- Join community discussions
+- Report issues on [GitHub Issues](https://github.com/langchain-ai/langchain-snowflake/issues)

--- a/libs/snowflake/docs/advanced_patterns.ipynb
+++ b/libs/snowflake/docs/advanced_patterns.ipynb
@@ -418,7 +418,7 @@
     "        # Create LLM with bound tools\n",
     "        self.llm = ChatSnowflake(\n",
     "            session=session, model=\"claude-4-sonnet\", temperature=0.1, max_tokens=1500\n",
-    "        ).bind_tools(self.all_tools, auto_execute=False)\n",
+    "        ).bind_tools(self.all_tools)\n",
     "\n",
     "    def run(self, query: str) -> str:\n",
     "        \"\"\"Execute query using pure native LLM tool selection.\"\"\"\n",


### PR DESCRIPTION
- Remove auto_execute parameter from bind_tools() to align with LangChain standards
- Delete auto-execute logic blocks from _parse_rest_api_response() methods
- Remove helper methods: _execute_planned_tools, _execute_planned_tools_async, _find_bound_tool, _combine_content_with_tool_results
- Fix MCP integration sync invocation error by adding proper async support
- Add arun() method to MCPToolWrapper for async tool execution
- Update create_langchain_tool_from_mcp() to use coroutine parameter
- Update all notebook examples to remove auto_execute references
- Resolves GitHub issue #22: duplicate tool results in AIMessage content

Breaking changes:
- auto_execute parameter removed from bind_tools()
- Tools now follow standard LangChain ReAct pattern (AIMessage → ToolMessage → AIMessage)
- MCP tools require async execution (use ainvoke() instead of invoke())